### PR TITLE
Added `filter_unpermitted_params` option.

### DIFF
--- a/example/app.rb
+++ b/example/app.rb
@@ -58,4 +58,22 @@ class Application < Sinatra::Base
       halt 500, 'invalid'
     end
   end
+
+  get '/filter' do
+    validates filter_unpermitted_params: true do
+      params do
+        optional(:allowed).filled(:str?)
+      end
+    end
+    params.map{|k, v| "#{k}=#{v}"}.join(' ')
+  end
+
+  get '/result' do
+    result = validates do
+      params do
+        optional(:allowed).filled(:str?)
+      end
+    end
+    result.params.map{|k, v| "#{k}=#{v}"}.join(' ')
+  end
 end

--- a/lib/sinatra/validation/version.rb
+++ b/lib/sinatra/validation/version.rb
@@ -1,5 +1,5 @@
 module Sinatra
   module Validation
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end

--- a/spec/sinatra/validation_spec.rb
+++ b/spec/sinatra/validation_spec.rb
@@ -30,4 +30,16 @@ RSpec.describe Sinatra::Validation do
     expect(last_response.status).to eql(500)
     expect(last_response.body).to eql('invalid')
   end
+
+  it "filter params with `filter_unpermitted_params`" do
+    get '/filter?allowed=ok&filtered=nok'
+    expect(last_response.status).to eql(200)
+    expect(last_response.body).to eql("allowed=ok")
+  end
+
+  it "filter params and set them in result" do
+    get '/result?allowed=ok&filtered=nok'
+    expect(last_response.status).to eql(200)
+    expect(last_response.body).to eql("allowed=ok")
+  end
 end


### PR DESCRIPTION
Hi there,

I needed to filter out unpermitted parameters so I added an option which might be of some interest to others.

This option allows to remove parameters not explicitly covered by validations from the Sinatra params hash.

Additionally, the Sinatra::Validation::Result created from params validation now always contains only validated params and is always returned so it's also easier to get this without altering original params Hash. I've also made sure the underlying Hash are Sinatra::IndifferentHash.

As other sinatra-validation options, you can either pass it as an option to `#validates` or by setting `enable :filter_unpermitted_params` at application level.

I'll add some tests to this PR if you're interested in merging this